### PR TITLE
Fix bad envvar syntax in GitHub Action

### DIFF
--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -17,8 +17,7 @@ jobs:
     - if: ${{ failure() && github.event_name == 'push' }} # only run failed master build
       run: ./slack-notify.sh
       env:
-        SLACK_TOKEN:
-          ${{ secrets.SLACK_TOKEN }}
+        SLACK_TOKEN: ${{ secrets.SLACK_TOKEN }}
 
   release:
     runs-on: ubuntu-latest

--- a/slack-notify.sh
+++ b/slack-notify.sh
@@ -11,7 +11,7 @@ SLACK_HOOK_URL="https://hooks.slack.com/services/${SLACK_TOKEN}"
 : "${GITHUB_SERVER_URL:=https://github.com}"
 : "${GITHUB_API_URL:=https://api.github.com}"
 : "${GITHUB_SHA:=$(git rev-parse HEAD)}"
-: "${PICTURE_BASE_URL:=https://github.com/foxgoat/howl/raw/master}"
+: "${PICTURE_BASE_URL:=https://github.com/foxygoat/howl/raw/master}"
 
 if [[ -z "${GITHUB_REPOSITORY-}" ]]; then
     REPO_URL=$(git remote get-url origin)

--- a/slack-notify.sh
+++ b/slack-notify.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 set -euo pipefail
+trap 'echo failed: line $LINENO: $BASH_COMMAND' ERR
 
 if [[ -z "${SLACK_TOKEN-}" ]]; then
     read -r SLACK_TOKEN


### PR DESCRIPTION
Fix bad environment variable syntax on GitHub Action. The result of this
incorrect syntax was the SLACK_TOKEN not being passed through correctly
which led to HTTP status 400 on curl calls to the Slack Webhook API.
This update fixes it.

Also add a debug line to the slack-notify.sh script so that the on
failure we can more easily find the command that caused the error.

Fix typo in picture base URL