### PR TITLE
make: Fix NEXT_TAG variable

### DIFF
--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -29,8 +29,7 @@ jobs:
     needs: [ci, release]
     if: always() && github.event_name == 'push' && (needs.ci.result == 'failure' || needs.release.result == 'failure')
     steps:
-    - uses: actions/checkout@v2
-    - run: ./slack-notify.sh
+    - uses: foxygoat/howl@v1
       env:
         SLACK_TOKEN: ${{ secrets.SLACK_TOKEN }}
         SLACK_TEXT: <!here|here>

--- a/Makefile
+++ b/Makefile
@@ -17,10 +17,13 @@ format:  ## Format shell scripts
 
 # --- Release -------------------------------------------------------------------
 NEXT_TAG := $(shell { git tag --list --merged HEAD --sort=-v:refname; echo v0.0.0; } | grep -E "^v?[0-9]+.[0-9]+.[0-9]+$$" | head -n1 | awk -F . '{ print $$1 "." $$2 "." $$3 + 1 }')
+MAJOR_RELEASE := $(firstword $(subst ., ,$(NEXT_TAG)))
 
 release:  ## Tag release
 	git tag --annotate $(NEXT_TAG)
 	git push origin $(NEXT_TAG)
+	git branch -f $(MAJOR_RELEASE)
+	git push origin $(MAJOR_RELEASE)
 
 .PHONY: release
 

--- a/Makefile
+++ b/Makefile
@@ -16,11 +16,11 @@ format:  ## Format shell scripts
 .PHONY: all check format
 
 # --- Release -------------------------------------------------------------------
-NEXTTAG := $(shell { git tag --list --merged HEAD --sort=-v:refname; echo v0.0.0; } | grep -E "^v?[0-9]+.[0-9]+.[0-9]+$$" | head -n1 | awk -F . '{ print $$1 "." $$2 "." $$3 + 1 }')
+NEXT_TAG := $(shell { git tag --list --merged HEAD --sort=-v:refname; echo v0.0.0; } | grep -E "^v?[0-9]+.[0-9]+.[0-9]+$$" | head -n1 | awk -F . '{ print $$1 "." $$2 "." $$3 + 1 }')
 
 release:  ## Tag release
-	git tag --annotate $(NEXTAG)
-	git push origin $(NEXTTAG)
+	git tag --annotate $(NEXT_TAG)
+	git push origin $(NEXT_TAG)
 
 .PHONY: release
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ jobs:
     needs: [ci]
     if: always && github.event_name == 'push' && needs.ci.result == 'failure'
     steps:
-    - uses: foxygoat/howl@1
+    - uses: foxygoat/howl@v1
       env:
         SLACK_TOKEN: ${{ secrets.SLACK_TOKEN }}
         SLACK_TEXT: <!here|here>
@@ -72,7 +72,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - if: ${{ contains(github.event.branches.*.name, 'master') && (github.event.state == 'failure' || github.event.state == 'error')}}
-      uses: foxygoat/howl@1
+      uses: foxygoat/howl@v1
       env:
         SLACK_TOKEN: ${{ secrets.SLACK_TOKEN }}
         BUILD_URL: ${{ github.event.target_url }}

--- a/slack-notify.sh
+++ b/slack-notify.sh
@@ -69,7 +69,7 @@ curl -fsSL -d @- "${SLACK_HOOK_URL}" <<EOF
 {
  "icon_url": "${PICTURE_BASE_URL}/icon.png",
  ${CHANNEL}
- "username": "${SLACK_USERNAME:-GitHub}",
+ "username": "${SLACK_USERNAME:-Howl}",
  ${SLACK_TEXT}
  "attachments": [
       {


### PR DESCRIPTION
Fix NEXT_TAG variable from typo with missing `T`, which resulted in
missing releases. Add `_` to avoid this mistake in the future and make
it more readable.

Rename Slack user to Howl.

Reference foxygoat/howl@v1 action inside GitHub workflow run.