### PR TITLE
Add user info env vars for annotated tags

### DIFF
--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -22,6 +22,9 @@ jobs:
     - run: git fetch --prune --unshallow --tags
     - run: ./bin/hermit env -r >> $GITHUB_ENV
     - run: make release
+      env:
+        EMAIL: releases@foxygo.at
+        GIT_COMMITTER_NAME: Foxygoat Releases
     - run: false
 
   howl-on-failure:


### PR DESCRIPTION
Set the GIT_COMMITTER and EMAIL env vars to something so
that annotated tags can be created. These tags contain info about the
user creating the tag (much like a commit does) and git will refuse to
create the tag if this information is not available.

We use a bogus email address - I mean, who uses email anymore?