### PR TITLE
github: Remove simulated master build failure

### DIFF
--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -25,7 +25,6 @@ jobs:
       env:
         EMAIL: releases@foxygo.at
         GIT_COMMITTER_NAME: Foxygoat Releases
-    - run: false
 
   howl-on-failure:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Remove simulated master build failure, as we have now proven that the
action works as intended.