### PR TITLE
github: Fix @here usage on GitHub Action usage

### DIFF
--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -36,4 +36,4 @@ jobs:
       - uses: foxygoat/howl@v1
         env:
           SLACK_TOKEN: ${{ secrets.SLACK_TOKEN }}
-          SLACK_TEXT: <!here|here>
+          SLACK_TEXT: <!here>

--- a/README.md
+++ b/README.md
@@ -6,13 +6,13 @@ Howl is a GitHub Action. It writes a custom Slack message with an
 optional `@here` or `@project-owners` to your preferred Slack channel.
 
 <div style="text-align:center;width:100%">
-	<img src="howler.jpeg" alt="Howler Monkey"/>
-	<br/>
-	<sub>Howler Monkey -
-		<a href="https://commons.wikimedia.org/wiki/File:DSC09108_-_Guyanan_Red_Howler_Monkey_(36384553204).jpg">
-			Wikimedia, CC BY-SA 2.0
-		</a>
-	</sub>
+  <img src="howler.jpeg" alt="Howler Monkey"/>
+  <br/>
+  <sub>Howler Monkey -
+    <a href="https://commons.wikimedia.org/wiki/File:DSC09108_-_Guyanan_Red_Howler_Monkey_(36384553204).jpg">
+      Wikimedia, CC BY-SA 2.0
+    </a>
+  </sub>
 </div>
 
 ## Set up Slack token
@@ -21,11 +21,11 @@ Set up a repository or organisation secrets with your [Incoming Slack
 Webhook] token. Use, for instance, `SLACK_TOKEN`. The content should
 look similar to
 
-	T01A*******/B0259*****/GcXTiEux*******************
+    T01A*******/B0259*****/GcXTiEux*******************
 
 Taken from the Slack provided Incoming Webhook URL:
 
-	https://hooks.slack.com/services/T01A*******/B0259*****/GcXTiEux*******************
+    https://hooks.slack.com/services/T01A*******/B0259*****/GcXTiEux*******************
 
 [Incoming Slack Webhook]: https://slack.com/intl/en-au/help/articles/115005265063-Incoming-webhooks-for-Slack
 
@@ -35,25 +35,25 @@ Taken from the Slack provided Incoming Webhook URL:
 name: ci
 on:
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
 
 jobs:
   ci:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-      run: make
+      - uses: actions/checkout@v2
+        run: make
   howl-on-failure:
     runs-on: ubuntu-latest
     needs: [ci]
     if: always && github.event_name == 'push' && needs.ci.result == 'failure'
     steps:
-    - uses: foxygoat/howl@v1
-      env:
-        SLACK_TOKEN: ${{ secrets.SLACK_TOKEN }}
-        SLACK_TEXT: <!here|here>    # optional; text or @-mention project owners by slack member ID, e.g. <@U0LAN0Z89>
-        #CHANNEL: D01J5K3RLQJ       # optional; use if different from slack webhook setup, take from channel URL
+      - uses: foxygoat/howl@v1
+        env:
+          SLACK_TOKEN: ${{ secrets.SLACK_TOKEN }}
+          SLACK_TEXT: <!here|here> # optional; text or @-mention project owners by slack member ID, e.g. <@U0LAN0Z89>
+          #CHANNEL: D01J5K3RLQJ       # optional; use if different from slack webhook setup, take from channel URL
 ```
 
 ## Use with external CI system
@@ -71,11 +71,11 @@ jobs:
   slack-notify:
     runs-on: ubuntu-latest
     steps:
-    - if: ${{ contains(github.event.branches.*.name, 'master') && (github.event.state == 'failure' || github.event.state == 'error')}}
-      uses: foxygoat/howl@v1
-      env:
-        SLACK_TOKEN: ${{ secrets.SLACK_TOKEN }}
-        BUILD_URL: ${{ github.event.target_url }}
-        #SLACK_TEXT: <!here|here>   # optional; text or @-mention project owners by slack member ID, e.g. <@U0LAN0Z89>
-        #CHANNEL: D01J5K3RLQJ       # optional; use if different from slack webhook setup, take from channel URL
+      - if: ${{ contains(github.event.branches.*.name, 'master') && (github.event.state == 'failure' || github.event.state == 'error')}}
+        uses: foxygoat/howl@v1
+        env:
+          SLACK_TOKEN: ${{ secrets.SLACK_TOKEN }}
+          BUILD_URL: ${{ github.event.target_url }}
+          #SLACK_TEXT: <!here|here>   # optional; text or @-mention project owners by slack member ID, e.g. <@U0LAN0Z89>
+          #CHANNEL: D01J5K3RLQJ       # optional; use if different from slack webhook setup, take from channel URL
 ```

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ jobs:
       - uses: foxygoat/howl@v1
         env:
           SLACK_TOKEN: ${{ secrets.SLACK_TOKEN }}
-          SLACK_TEXT: <!here|here> # optional; text or @-mention project owners by slack member ID, e.g. <@U0LAN0Z89>
+          SLACK_TEXT: <!here> # optional; text or @-mention project owners by slack member ID, e.g. <@U0LAN0Z89>
           #CHANNEL: D01J5K3RLQJ       # optional; use if different from slack webhook setup, take from channel URL
 ```
 
@@ -76,6 +76,6 @@ jobs:
         env:
           SLACK_TOKEN: ${{ secrets.SLACK_TOKEN }}
           BUILD_URL: ${{ github.event.target_url }}
-          #SLACK_TEXT: <!here|here>   # optional; text or @-mention project owners by slack member ID, e.g. <@U0LAN0Z89>
+          #SLACK_TEXT: <!here>   # optional; text or @-mention project owners by slack member ID, e.g. <@U0LAN0Z89>
           #CHANNEL: D01J5K3RLQJ       # optional; use if different from slack webhook setup, take from channel URL
 ```


### PR DESCRIPTION
According to docs this is a valid example for `@here` usage in formatted
text:

    Hey <!here>, there's a new task in your queue.

Update accordingly.
This has been tested manually.

Link: https://api.slack.com/reference/surfaces/formatting