### PR TITLE
docs: Fix YAML syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,5 +89,5 @@ jobs:
           slack-channel: C0000000000 # optional; channel ID
           slack-text: <!here> # optional; text or @-mention
           discord-webhook-url: ${{ secrets.DISCORD_WEBHOOK_URL }}
-          discord-text: @here # optional; text or @-mention
+          discord-text: '@here' # optional; text or @-mention
 ```


### PR DESCRIPTION
Fix YAML syntax in GitHub Action sample in README.md. `@` character is
reserved for future use in YAML and cannot be used unquoted:

	The “@” (#x40, at) and “`” (#x60, grave accent) are reserved for future use.

Link: https://yaml.org/spec/1.2.2/

---

I'll use this PR to see if auto-versioning works for hermit-packages.